### PR TITLE
Changing href for Intranet Sign-in from  /login to /dashboard

### DIFF
--- a/public/cart.html
+++ b/public/cart.html
@@ -269,7 +269,7 @@
           </ul>
           <ul class="p-2">
             <li class="mb-3"><a href="#">Management</a></li>
-            <!-- href changed from /login to /dashboard due Heroku doesn't close logging session after the user has not logged out from the management system,  and an error is produce. -->after user has not logout from management system and launchs and error. -->
+            <!-- href changed from /login to /dashboard due Heroku doesn't close logging session after the user has not logged out from the management system,  and an error is produce. -->
             <li><a class="text-dark" href="/dashboard"> Intranet Sign-in</a></li>
           </ul>
           <ul class="p-2">

--- a/public/index.html
+++ b/public/index.html
@@ -236,7 +236,7 @@
           </ul>
           <ul class="p-2">
             <li class="mb-3"><a href="#">Management</a></li>
-            <!-- href changed from /login to /dashboard due Heroku doesn't close logging session after the user has not logged out from the management system,  and an error is produce. -->after user has not logout from management system and launchs and error. -->
+            <!-- href changed from /login to /dashboard due Heroku doesn't close logging session after the user has not logged out from the management system,  and an error is produce. -->
             <li><a class="text-dark" href="/dashboard"> Intranet Sign-in</a></li> 
           </ul>
           <ul class="p-2">


### PR DESCRIPTION
href changed from /login to /dashboard due Heroku doesn't close logging session after the user has not logged out from the management system,  and an error is produced
